### PR TITLE
Use appropriate cache flags

### DIFF
--- a/lib/http-cache/storage.js
+++ b/lib/http-cache/storage.js
@@ -59,12 +59,13 @@ Storage.prototype.handleRequest = function(req, res) {
   var evaluator = new context.RequestEvaluationContext(req);
 
   this.emit('request', req, res, evaluator);
-  if (!!evaluator.cacheable) {
+  if (!!evaluator.retrievable) {
     if (this.serveCached(req, res)) {
       return true;
-    } else {
-      this.prepareWrappers(req, res);
     }
+  }
+  if (!!evaluator.storable) {
+    this.prepareWrappers(req, res);
   }
 
   return false;

--- a/test/http-cache/storage/memory-test.js
+++ b/test/http-cache/storage/memory-test.js
@@ -8,6 +8,7 @@
 var helper    = require('../../test-helper')
   , shared    = require('../../support/shared-examples')
   , httpCache = helper.httpCache
+  , assert    = require('assert')
   , memo      = helper.memo
   ;
 
@@ -17,4 +18,24 @@ describe('httpCache.storage.MemoryStorage', function(){
   });
 
   shared.behavesLikeACacheStorage(storage);
+
+  var method  = memo().is(function(){ return 'GET' });
+  var headers = memo().is(function(){ return {} });
+
+  var req = memo().is(function(){
+    return helper.createRequest({
+      method:  method(),
+      headers: headers()
+    });
+  });
+
+  var res = memo().is(function(){
+    return helper.createResponse(req());
+  });
+
+  it('tries to serve cache if cacheable', function(){
+    var serveCachedSpy = helper.sinon.spy(storage(), 'serveCached');
+    storage().handleRequest(req(), res());
+    assert(serveCachedSpy.called);
+  });
 });


### PR DESCRIPTION
`evaluator.cacheable` no longer seems to be available. Using `evaluator.retrievable` and `evaluator.storable` to handle requests properly.
